### PR TITLE
Fix: Properly escape `<head>` tag in README documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,7 @@ You can import the file into your stylesheet as follows:
 NOTE: The directory where the stylesheet is placed.
 
 2. Link a stylesheet
-You may also link to the stylesheet in the <head> of the HTML document:
-
+You may also link to the stylesheet in the `<head>` of the HTML document:
 ```
 <link rel="stylesheet" type="text/css" href="webfonts/balsamiqsans.css">
 ```


### PR DESCRIPTION
The <head> HTML tag was not being properly displayed in the rendered markdown due to being interpreted as an actual HTML element. Wrapped it in backticks to properly escape it so it displays as inline code.