### PR TITLE
fix: bump pillow, sh, and setuptools to remediate Dependabot alerts

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -224,7 +224,7 @@ packaging==26.2
     #   gftools
 picosvg==0.22.3
     # via nanoemoji
-pillow==12.2.0
+pillow==12.3.0
     # via
     #   diffenator2
     #   gftools
@@ -300,7 +300,7 @@ ruamel-yaml==0.19.1
     # via gftools
 selenium==4.44.0
     # via diffenator2
-sh==2.2.2
+sh==2.4.0
     # via -r requirements.in
 shaperglot==1.2.0
     # via fontbakery
@@ -422,5 +422,5 @@ zopfli==0.4.2
 # The following packages are considered to be unsafe in a requirements file:
 pip==26.1.2
     # via pip-api
-setuptools==82.0.1
+setuptools==83.0.0
     # via glyphsets


### PR DESCRIPTION
## Summary
- Resolves 15 open Dependabot alerts on `requirements.txt`
- `pillow` 12.2.0 → 12.3.0 (10 alerts: 7 high, 3 medium — image-parsing heap overflows, OOB read/write, DoS)
- `sh` 2.2.2 → 2.4.0 (1 high alert, CVE-2026-54552)
- `setuptools` 82.0.1 → 83.0.0 (1 medium alert, CVE-2026-59890 — MANIFEST.in exclusion bypass via Unicode normalization on macOS)

Generated via `pip-compile --allow-unsafe --upgrade-package pillow --upgrade-package sh --upgrade-package setuptools requirements.in`, so only these three pins changed — all other locked versions are untouched.

## Test plan
- [ ] Confirm the three Dependabot alerts' corresponding GHSA entries close once merged
- [ ] Run the normal font build pipeline to confirm no regressions from the Pillow/setuptools bump

🤖 Generated with [Claude Code](https://claude.com/claude-code)